### PR TITLE
Fix API URL env var mismatch

### DIFF
--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -1,7 +1,8 @@
 /**
  * API endpoints
  */
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api';
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000/api';
 export const USER_ENDPOINT = `${API_BASE_URL}/users/`;
 
 /**


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_BACKEND_URL` in API constants

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd88360988325a356164b56080c62